### PR TITLE
udpSessionRegistry changed to store sessionId object instead of IP ad…

### DIFF
--- a/nadclient/src/main/java/io/nadron/client/NettyUDPClient.java
+++ b/nadclient/src/main/java/io/nadron/client/NettyUDPClient.java
@@ -254,7 +254,7 @@ public class NettyUDPClient
 					+ " Passed to connect method is not bound");
 		}
 
-		Event event = Events.event(null, Events.CONNECT);
+		Event event = Events.event(null, Events.CONNECT, session);
 		
 		ChannelFuture future = datagramChannel.write(event);
 		future.addListener(new ChannelFutureListener()

--- a/nadclient/src/main/java/io/nadron/client/NettyUDPClient.java
+++ b/nadclient/src/main/java/io/nadron/client/NettyUDPClient.java
@@ -58,7 +58,7 @@ public class NettyUDPClient
 	 * {@link UDPUpstreamHandler} will resolve which session to pass the event,
 	 * using this map.
 	 */
-	public static final Map<InetSocketAddress, Session> CLIENTS = new HashMap<InetSocketAddress, Session>();
+	public static final Map<Object, Session> CLIENTS = new HashMap<Object, Session>();
 
 	/**
 	 * Creates an instance of a Netty UDP client which can then be used to
@@ -269,7 +269,7 @@ public class NettyUDPClient
 				}
 			}
 		});
-		CLIENTS.put(datagramChannel.localAddress(), session);
+		CLIENTS.put(session.getId(), session);
 		return future;
 	}
 

--- a/nadclient/src/main/java/io/nadron/client/event/Event.java
+++ b/nadclient/src/main/java/io/nadron/client/event/Event.java
@@ -19,4 +19,8 @@ public interface Event
 	long getTimeStamp();
 
 	void setTimeStamp(long timeStamp);
+
+	Object getSessionId();
+
+	void setSessionId(Object sessionId);
 }

--- a/nadclient/src/main/java/io/nadron/client/event/Events.java
+++ b/nadclient/src/main/java/io/nadron/client/event/Events.java
@@ -1,5 +1,6 @@
 package io.nadron.client.event;
 
+import io.nadron.client.app.Session;
 import io.nadron.client.communication.DeliveryGuaranty;
 import io.nadron.client.communication.DeliveryGuaranty.DeliveryGuarantyOptions;
 import io.nadron.client.event.impl.AbstractSessionEventHandler;
@@ -117,13 +118,19 @@ public class Events
 		networkEvent.setDeliveryGuaranty(deliveryGuaranty);
 		return networkEvent;
 	}
-	
+
 	public static Event event(Object source, int eventType)
+	{
+		return event(source,eventType,(Session)null);
+	}
+
+	public static Event event(Object source, int eventType, Session session)
 	{
 		DefaultEvent event = new DefaultEvent();
 		event.setSource(source);
 		event.setType(eventType);
 		event.setTimeStamp(System.currentTimeMillis());
+		event.setSessionId(session.getId());
 		return event;
 	}
 

--- a/nadclient/src/main/java/io/nadron/client/event/impl/DefaultEvent.java
+++ b/nadclient/src/main/java/io/nadron/client/event/impl/DefaultEvent.java
@@ -62,6 +62,16 @@ public class DefaultEvent implements Event, Serializable
 	}
 
 	@Override
+	public Object getSessionId() {
+		return sessionId;
+	}
+
+	@Override
+	public void setSessionId(Object sessionId) {
+		this.sessionId = sessionId;
+	}
+
+	@Override
 	public String toString()
 	{
 		return "Event [type=" + type + ", source=" + source + ", timeStamp="

--- a/nadclient/src/main/java/io/nadron/client/handlers/netty/UDPUpstreamHandler.java
+++ b/nadclient/src/main/java/io/nadron/client/handlers/netty/UDPUpstreamHandler.java
@@ -34,10 +34,10 @@ public class UDPUpstreamHandler extends SimpleChannelInboundHandler<DatagramPack
 	public void channelRead0(ChannelHandlerContext ctx,
 			DatagramPacket packet) throws Exception
 	{
-		Session session = NettyUDPClient.CLIENTS.get(ctx.channel().localAddress());
+		Event event = (Event)decoder.decode(null, packet.content());
+		Session session = NettyUDPClient.CLIENTS.get(event.getSessionId());
 		if (null != session)
 		{
-			Event event = (Event)decoder.decode(null, packet.content());
 			// Pass the event on to the session
 			session.onEvent(event);
 		}

--- a/nadron/src/main/java/io/nadron/communication/NettyUDPMessageSender.java
+++ b/nadron/src/main/java/io/nadron/communication/NettyUDPMessageSender.java
@@ -33,16 +33,19 @@ public class NettyUDPMessageSender implements Fast
 	private static final Logger LOG = LoggerFactory
 			.getLogger(NettyUDPMessageSender.class);
 	private final SocketAddress remoteAddress;
+	private final Session session;
 	private final DatagramChannel channel;
-	private final SessionRegistryService<SocketAddress> sessionRegistryService;
+	private final SessionRegistryService<Object> sessionRegistryService;
 	private final EventContext eventContext;
 	private static final DeliveryGuaranty DELIVERY_GUARANTY = DeliveryGuarantyOptions.FAST;
 
 	public NettyUDPMessageSender(SocketAddress remoteAddress,
 			DatagramChannel channel,
-			SessionRegistryService<SocketAddress> sessionRegistryService)
+			SessionRegistryService<Object> sessionRegistryService,
+								 Session session)
 	{
 		this.remoteAddress = remoteAddress;
+		this.session = session;
 		this.channel = channel;
 		this.sessionRegistryService = sessionRegistryService;
 		this.eventContext = new EventContextImpl((InetSocketAddress)remoteAddress);
@@ -67,14 +70,13 @@ public class NettyUDPMessageSender implements Fast
 	@Override
 	public void close()
 	{
-		Session session = sessionRegistryService.getSession(remoteAddress);
-		if (sessionRegistryService.removeSession(remoteAddress))
+		if (sessionRegistryService.removeSession((String) session.getId()))
 		{
 			LOG.debug("Successfully removed session: {}", session);
 		}
 		else
 		{
-			LOG.trace("No udp session found for address: {}", remoteAddress);
+			LOG.trace("No udp session found for session: {}", session);
 		}
 
 	}
@@ -106,7 +108,7 @@ public class NettyUDPMessageSender implements Fast
 		return sender;
 	}
 
-	protected SessionRegistryService<SocketAddress> getSessionRegistryService()
+	protected SessionRegistryService<Object> getSessionRegistryService()
 	{
 		return sessionRegistryService;
 	}

--- a/nadron/src/main/java/io/nadron/event/Event.java
+++ b/nadron/src/main/java/io/nadron/event/Event.java
@@ -17,4 +17,9 @@ public interface Event
 	long getTimeStamp();
 
 	void setTimeStamp(long timeStamp);
+
+	Object getSessionId();
+
+	void setSessionId(Object sessionId);
+
 }

--- a/nadron/src/main/java/io/nadron/event/Events.java
+++ b/nadron/src/main/java/io/nadron/event/Events.java
@@ -90,14 +90,19 @@ public class Events
 		return event(source,eventType,(Session)null);
 	}
 	
-	public static Event event(Object source, int eventType,Session session)
+	public static Event event(Object source, int eventType, Session session)
 	{
 		EventContext context = null;
 		if(null != session)
 		{
 			context = new DefaultEventContext();
 		}
-		return event(source,eventType,context);
+		Event event = event(source,eventType,context);
+		if(null != session)
+		{
+			event.setSessionId(session.getId());
+		}
+		return event;
 	}
 	
 	public static Event event(Object source, int eventType, EventContext context)
@@ -114,7 +119,7 @@ public class Events
 	 * Creates a network event with the source set to the object passed in as
 	 * parameter and the {@link DeliveryGuaranty} set to
 	 * {@link DeliveryGuarantyOptions#RELIABLE}. This method delegates to
-	 * {@link #networkEvent(Object, DeliveryGuaranty)}.
+	 * {@link #networkEvent(Object, Session, DeliveryGuaranty)}.
 	 * 
 	 * @param source
 	 *            The payload of the event. This is the actual data that gets
@@ -123,7 +128,7 @@ public class Events
 	 */
 	public static NetworkEvent networkEvent(Object source)
 	{
-		return networkEvent(source,DeliveryGuaranty.DeliveryGuarantyOptions.RELIABLE);
+		return networkEvent(source, null, DeliveryGuaranty.DeliveryGuarantyOptions.RELIABLE);
 	}
 	
 	/**
@@ -139,9 +144,9 @@ public class Events
 	 *            message to remote machine.
 	 * @return An instance of {@link NetworkEvent}
 	 */
-	public static NetworkEvent networkEvent(Object source, DeliveryGuaranty deliveryGuaranty)
+	public static NetworkEvent networkEvent(Object source, Session session, DeliveryGuaranty deliveryGuaranty)
 	{
-		Event event = event(source,Events.NETWORK_MESSAGE);
+		Event event = event(source, Events.NETWORK_MESSAGE, session);
 		NetworkEvent networkEvent = new DefaultNetworkEvent(event);
 		networkEvent.setDeliveryGuaranty(deliveryGuaranty);
 		return networkEvent;

--- a/nadron/src/main/java/io/nadron/event/impl/DefaultEvent.java
+++ b/nadron/src/main/java/io/nadron/event/impl/DefaultEvent.java
@@ -18,6 +18,7 @@ public class DefaultEvent implements Event, Serializable
 	protected int type;
 	protected Object source;
 	protected long timeStamp;
+	protected Object sessionId;
 	private String cName;
 	
 	@Override
@@ -67,6 +68,16 @@ public class DefaultEvent implements Event, Serializable
 	{
 		this.timeStamp = timeStamp;
 
+	}
+
+	@Override
+	public Object getSessionId() {
+		return sessionId;
+	}
+
+	@Override
+	public void setSessionId(Object sessionId) {
+		this.sessionId = sessionId;
 	}
 
 	@Override


### PR DESCRIPTION
…dress, event messages no have an optional sessionId field to link UDP session to TCP session. Java client has been modified correspondingly. This is to allow UDP to work when played behind  NAT, when client public IP address may not be known or unique, as per discussion here:

https://groups.google.com/forum/#!topic/jetserver/5rIxGCsgYac